### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/TrustlabTech/ecd-jobs-service.png?label=ready&title=Ready)](https://waffle.io/TrustlabTech/ecd-jobs-service?utm_source=badge)
 # Jobs Queue for ECD API
 
 ## Endpoints


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/TrustlabTech/ecd-jobs-service

This was requested by a real person (user lsconsent) on waffle.io, we're not trying to spam you.